### PR TITLE
Add tests for CPU simulator components

### DIFF
--- a/CPU_Simulator/pom.xml
+++ b/CPU_Simulator/pom.xml
@@ -38,6 +38,24 @@
             <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+</dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/CPU_Simulator/src/test/java/component/register/ExMemTest.java
+++ b/CPU_Simulator/src/test/java/component/register/ExMemTest.java
@@ -1,0 +1,46 @@
+package component.register;
+
+import component.unit.Execute;
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExMemTest {
+
+    @Test
+    void testUpdate() {
+        Instruction instr = new Instruction(Instruction.ZERO_16);
+        IdEx idEx = new IdEx();
+        idEx.setInstruction(instr);
+        idEx.setReadData2("0000000000000011");
+        idEx.setBranch(true);
+        idEx.setMemoryWrite(true);
+        idEx.setMemoryToRegister(true);
+        idEx.setRegisterWrite(true);
+
+        Execute execute = new Execute();
+        execute.setBranchAddress("0000000000000010");
+        execute.setAluResult("0000000000000100");
+        execute.setRWa("010");
+        execute.setZero(true);
+
+        ExMem exMem = new ExMem();
+        exMem.initializeRegisters(Map.of("IdEx", idEx));
+        exMem.initializeUnits(Map.of("Execute", execute));
+        exMem.update();
+
+        assertEquals(instr, exMem.getInstruction());
+        assertEquals("0000000000000010", exMem.getBranchAddress());
+        assertEquals("0000000000000100", exMem.getAluResult());
+        assertEquals("010", exMem.getRd());
+        assertEquals("0000000000000011", exMem.getReadData2());
+        assertTrue(exMem.isBranch());
+        assertTrue(exMem.isMemoryWrite());
+        assertTrue(exMem.isMemoryToRegister());
+        assertTrue(exMem.isRegisterWrite());
+        assertTrue(exMem.isZero());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/register/IdExTest.java
+++ b/CPU_Simulator/src/test/java/component/register/IdExTest.java
@@ -1,0 +1,61 @@
+package component.register;
+
+import component.unit.Control;
+import component.unit.InstructionDecoder;
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdExTest {
+
+    @Test
+    void testUpdate() {
+        Instruction instruction = new Instruction(Instruction.ZERO_16);
+        IfId ifId = new IfId();
+        ifId.setInstruction(instruction);
+        ifId.setPcIncrement("0000000000000001");
+
+        InstructionDecoder decoder = new InstructionDecoder();
+        decoder.setReadData1("0000000000000010");
+        decoder.setReadData2("0000000000000011");
+        decoder.setExtendedImmediate("0000000000000100");
+        decoder.setFunc("101");
+        decoder.setRd("010");
+        decoder.setRt("011");
+        decoder.setSa(true);
+
+        Control control = new Control();
+        control.setAluOperation("110");
+        control.setRegisterDestination(true);
+        control.setAluSource(true);
+        control.setBranch(true);
+        control.setMemoryWrite(true);
+        control.setMemoryToRegister(true);
+        control.setRegisterWrite(true);
+
+        IdEx idEx = new IdEx();
+        idEx.initializeUnits(Map.of("InstructionDecoder", decoder, "Control", control));
+        idEx.initializeRegisters(Map.of("IfId", ifId));
+        idEx.update();
+
+        assertEquals(instruction, idEx.getInstruction());
+        assertEquals("0000000000000010", idEx.getReadData1());
+        assertEquals("0000000000000011", idEx.getReadData2());
+        assertEquals("0000000000000100", idEx.getExtendedImmediate());
+        assertEquals("101", idEx.getFunc());
+        assertEquals("010", idEx.getRd());
+        assertEquals("011", idEx.getRt());
+        assertEquals("0000000000000001", idEx.getPcIncrement());
+        assertEquals("110", idEx.getAluOperation());
+        assertTrue(idEx.isRegisterDestination());
+        assertTrue(idEx.isAluSource());
+        assertTrue(idEx.isBranch());
+        assertTrue(idEx.isMemoryWrite());
+        assertTrue(idEx.isMemoryToRegister());
+        assertTrue(idEx.isRegisterWrite());
+        assertTrue(idEx.isSa());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/register/IfIdTest.java
+++ b/CPU_Simulator/src/test/java/component/register/IfIdTest.java
@@ -1,0 +1,25 @@
+package component.register;
+
+import component.unit.InstructionFetch;
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IfIdTest {
+
+    @Test
+    void testUpdate() {
+        InstructionFetch fetch = new InstructionFetch();
+        fetch.setInstruction(new Instruction(Instruction.ZERO_16));
+        fetch.setPcIncrement("0000000000000011");
+        IfId ifId = new IfId();
+        ifId.initializeUnits(Map.of("InstructionFetch", fetch));
+        ifId.initializeRegisters(Map.of());
+        ifId.update();
+        assertEquals(fetch.getInstruction(), ifId.getInstruction());
+        assertEquals("0000000000000011", ifId.getPcIncrement());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/register/MemWbTest.java
+++ b/CPU_Simulator/src/test/java/component/register/MemWbTest.java
@@ -1,0 +1,39 @@
+package component.register;
+
+import component.unit.Memory;
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemWbTest {
+
+    @Test
+    void testUpdate() {
+        Instruction instr = new Instruction(Instruction.ZERO_16);
+        ExMem exMem = new ExMem();
+        exMem.setInstruction(instr);
+        exMem.setAluResult("0000000000000100");
+        exMem.setRd("010");
+        exMem.setMemoryToRegister(true);
+        exMem.setRegisterWrite(true);
+
+        Memory memory = new Memory();
+        memory.setAluResultOut("0000000000000100");
+        memory.setMemoryData("0000000000000011");
+
+        MemWb memWb = new MemWb();
+        memWb.initializeRegisters(Map.of("ExMem", exMem));
+        memWb.initializeUnits(Map.of("Memory", memory));
+        memWb.update();
+
+        assertEquals(instr, memWb.getInstruction());
+        assertEquals("0000000000000100", memWb.getAluResult());
+        assertEquals("0000000000000011", memWb.getMemoryData());
+        assertEquals("010", memWb.getRd());
+        assertTrue(memWb.isMemoryToRegister());
+        assertTrue(memWb.isRegisterWrite());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/unit/ControlTest.java
+++ b/CPU_Simulator/src/test/java/component/unit/ControlTest.java
@@ -1,0 +1,56 @@
+package component.unit;
+
+import helper.instruction.Instruction;
+import component.register.IfId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ControlTest {
+    private Control control;
+
+    @BeforeEach
+    void setUp() {
+        control = new Control();
+        control.initializeRegisters(Map.of("IfId", new IfId()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("controlCases")
+    void testControlSignals(String opcode, boolean regDest, boolean extOp, boolean branch,
+                            boolean jump, boolean aluSource, boolean memWrite, boolean memToReg,
+                            boolean regWrite, String aluOp) {
+        IfId ifId = (IfId) control.getRegisters().get("IfId");
+        ifId.setInstruction(new Instruction(opcode + "0000000000000"));
+        control.update();
+        control.run();
+        assertEquals(regDest, control.isRegisterDestination());
+        assertEquals(extOp, control.isExtendedOperation());
+        assertEquals(branch, control.isBranch());
+        assertEquals(jump, control.isJump());
+        assertEquals(aluSource, control.isAluSource());
+        assertEquals(memWrite, control.isMemoryWrite());
+        assertEquals(memToReg, control.isMemoryToRegister());
+        assertEquals(regWrite, control.isRegisterWrite());
+        assertEquals(aluOp, control.getAluOperation());
+    }
+
+    private static Stream<Arguments> controlCases() {
+        return Stream.of(
+                Arguments.of("000", true, false, false, false, false, false, false, true, "000"),
+                Arguments.of("001", false, true, false, false, true, false, false, true, "100"),
+                Arguments.of("010", false, true, false, false, true, false, true, true, "100"),
+                Arguments.of("011", false, true, false, false, true, true, false, false, "100"),
+                Arguments.of("100", false, true, true, false, false, false, false, false, "001"),
+                Arguments.of("101", false, false, false, false, true, false, false, true, "101"),
+                Arguments.of("110", false, true, false, false, true, false, false, true, "110"),
+                Arguments.of("111", false, false, false, true, false, false, false, false, "000")
+        );
+    }
+}

--- a/CPU_Simulator/src/test/java/component/unit/ExecuteTest.java
+++ b/CPU_Simulator/src/test/java/component/unit/ExecuteTest.java
@@ -1,0 +1,45 @@
+package component.unit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExecuteTest {
+
+    @Test
+    void testRTypeAddition() {
+        Execute execute = new Execute();
+        execute.setRegisterDestination(true);
+        execute.setAluSource(false);
+        execute.setReadData1("0000000000000011");
+        execute.setReadData2("0000000000000001");
+        execute.setFunc("000");
+        execute.setAluOperation("000");
+        execute.setRd("010");
+        execute.setRt("011");
+        execute.setPcIncrement("0000000000000100");
+        execute.setExtendedImmediate("0000000000000010");
+        execute.run();
+        assertEquals("010", execute.getRWa());
+        assertEquals("0000000000000100", execute.getAluResult());
+        assertEquals("0000000000000110", execute.getBranchAddress());
+        assertFalse(execute.isZero());
+    }
+
+    @Test
+    void testImmediateAdditionProducesZero() {
+        Execute execute = new Execute();
+        execute.setRegisterDestination(false);
+        execute.setAluSource(true);
+        execute.setReadData1("0000000000000001");
+        execute.setExtendedImmediate("1111111111111111"); // -1 in two's complement
+        execute.setAluOperation("100"); // addition
+        execute.setRd("001");
+        execute.setRt("010");
+        execute.setPcIncrement("0000000000000000");
+        execute.run();
+        assertEquals("010", execute.getRWa());
+        assertEquals("0000000000000000", execute.getAluResult());
+        assertTrue(execute.isZero());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/unit/InstructionFetchTest.java
+++ b/CPU_Simulator/src/test/java/component/unit/InstructionFetchTest.java
@@ -1,0 +1,69 @@
+package component.unit;
+
+import component.register.ExMem;
+import component.register.IfId;
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InstructionFetchTest {
+
+    @Test
+    void testBranchFetchesCorrectInstruction() {
+        InstructionFetch fetch = new InstructionFetch();
+        IfId ifId = new IfId();
+        ifId.setInstruction(new Instruction(Instruction.ZERO_16));
+        ifId.setPcIncrement("0000000000000000");
+        ExMem exMem = new ExMem();
+        exMem.setBranchAddress("0000000000000001");
+        exMem.setBranch(true);
+        exMem.setZero(true);
+        Control control = new Control();
+        control.setJump(false);
+
+        fetch.initializeRegisters(Map.of("IfId", ifId, "ExMem", exMem));
+        fetch.initializeUnits(Map.of("Control", control));
+
+        List<Instruction> list = Arrays.asList(
+                new Instruction("0000000000000000"),
+                new Instruction("0000000000000001"),
+                new Instruction("0000000000000010")
+        );
+        fetch.setInstructions(list);
+        fetch.update();
+        fetch.run();
+        assertEquals(list.get(1), fetch.getInstruction());
+    }
+
+    @Test
+    void testJumpFetchesCorrectInstruction() {
+        InstructionFetch fetch = new InstructionFetch();
+        IfId ifId = new IfId();
+        ifId.setInstruction(new Instruction("1110000000000011"));
+        ifId.setPcIncrement("0000000000000000");
+        ExMem exMem = new ExMem();
+        exMem.setBranch(false);
+        exMem.setZero(false);
+        Control control = new Control();
+        control.setJump(true);
+
+        fetch.initializeRegisters(Map.of("IfId", ifId, "ExMem", exMem));
+        fetch.initializeUnits(Map.of("Control", control));
+
+        List<Instruction> list = Arrays.asList(
+                new Instruction("0000000000000000"),
+                new Instruction("0000000000000001"),
+                new Instruction("0000000000000010"),
+                new Instruction("0000000000000011")
+        );
+        fetch.setInstructions(list);
+        fetch.update();
+        fetch.run();
+        assertEquals(list.get(3), fetch.getInstruction());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/unit/MemoryTest.java
+++ b/CPU_Simulator/src/test/java/component/unit/MemoryTest.java
@@ -1,0 +1,31 @@
+package component.unit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemoryTest {
+
+    @Test
+    void testMemoryWriteAndRead() {
+        Memory memory = new Memory();
+        memory.setAluResultIn("0000000000000100");
+        memory.setReadData2("0000000000001010");
+        memory.setMemoryWrite(true);
+        memory.run();
+        assertEquals("0000000000001010", memory.getMemory()[4]);
+        assertEquals("0000000000000100", memory.getAluResultOut());
+        assertEquals("0000000000001010", memory.getMemoryData());
+    }
+
+    @Test
+    void testMemoryReadWithoutWrite() {
+        Memory memory = new Memory();
+        memory.getMemory()[2] = "0000000000001111";
+        memory.setAluResultIn("0000000000000010");
+        memory.setReadData2("0000000000000000");
+        memory.setMemoryWrite(false);
+        memory.run();
+        assertEquals("0000000000001111", memory.getMemoryData());
+    }
+}

--- a/CPU_Simulator/src/test/java/component/unit/WriteBackTest.java
+++ b/CPU_Simulator/src/test/java/component/unit/WriteBackTest.java
@@ -1,0 +1,36 @@
+package component.unit;
+
+import helper.instruction.Instruction;
+import helper.instruction.InstructionStage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WriteBackTest {
+
+    @Test
+    void testResultFromAlu() {
+        WriteBack writeBack = new WriteBack();
+        Instruction instr = new Instruction(Instruction.ZERO_16);
+        writeBack.setInstruction(instr);
+        writeBack.setAluRes("0000000000000011");
+        writeBack.setMemoryData("0000000000000100");
+        writeBack.setMemoryToRegister(false);
+        writeBack.run();
+        assertEquals("0000000000000011", writeBack.getResult());
+        writeBack.finishInstruction();
+        assertEquals(InstructionStage.FINISHED, instr.getInstructionStage());
+    }
+
+    @Test
+    void testResultFromMemory() {
+        WriteBack writeBack = new WriteBack();
+        Instruction instr = new Instruction(Instruction.ZERO_16);
+        writeBack.setInstruction(instr);
+        writeBack.setAluRes("0000000000000011");
+        writeBack.setMemoryData("0000000000000100");
+        writeBack.setMemoryToRegister(true);
+        writeBack.run();
+        assertEquals("0000000000000100", writeBack.getResult());
+    }
+}

--- a/CPU_Simulator/src/test/java/helper/CodeLoaderTest.java
+++ b/CPU_Simulator/src/test/java/helper/CodeLoaderTest.java
@@ -1,0 +1,24 @@
+package helper;
+
+import helper.instruction.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodeLoaderTest {
+
+    @Test
+    void testLoadCode() throws IOException {
+        Path temp = Files.createTempFile("program", ".txt");
+        Files.writeString(temp, "000_000_000_000_0_000\n001_000_001_0000001");
+        List<Instruction> instructions = CodeLoader.loadCode(temp.toString());
+        assertEquals(2, instructions.size());
+        assertEquals("0000000000000000", instructions.get(0).getInstruction());
+        assertEquals("0010000010000001", instructions.get(1).getInstruction());
+    }
+}

--- a/CPU_Simulator/src/test/java/helper/OperationTest.java
+++ b/CPU_Simulator/src/test/java/helper/OperationTest.java
@@ -1,0 +1,48 @@
+package helper;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OperationTest {
+
+    @Test
+    void testAddBinary() {
+        assertEquals("0000000000000010", Operation.addBinary("0000000000000001", "0000000000000001"));
+    }
+
+    @Test
+    void testSubtractBinary() {
+        assertEquals("0000000000000001", Operation.subtractBinary("0000000000000010", "0000000000000001"));
+    }
+
+    @Test
+    void testShiftLeftLogic() {
+        assertEquals("1000000000000000", Operation.shiftLeftLogic("0100000000000000"));
+    }
+
+    @Test
+    void testShiftRightLogic() {
+        assertEquals("0010000000000000", Operation.shiftRightLogic("0100000000000000"));
+    }
+
+    @Test
+    void testShiftRightArithmetic() {
+        assertEquals("1010000000000000", Operation.shiftRightArithmetic("1100000000000000"));
+    }
+
+    @Test
+    void testOr() {
+        assertEquals("0000000000000011", Operation.OR("0000000000000001", "0000000000000011"));
+    }
+
+    @Test
+    void testAnd() {
+        assertEquals("0000000000000001", Operation.AND("0000000000000001", "0000000000000011"));
+    }
+
+    @Test
+    void testSetOnLessThan() {
+        assertEquals("0000000000000001", Operation.setOnLessThan("0000000000000001", "0000000000000011"));
+        assertEquals("0000000000000000", Operation.setOnLessThan("0000000000000100", "0000000000000011"));
+    }
+}

--- a/CPU_Simulator/src/test/java/helper/instruction/InstructionTest.java
+++ b/CPU_Simulator/src/test/java/helper/instruction/InstructionTest.java
@@ -1,0 +1,27 @@
+package helper.instruction;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InstructionTest {
+
+    @Test
+    void testGlobalIdReset() {
+        Instruction.resetGlobalId();
+        Instruction i1 = new Instruction(Instruction.ZERO_16);
+        Instruction i2 = new Instruction(Instruction.ZERO_16);
+        assertEquals(1, i1.getId());
+        assertEquals(2, i2.getId());
+        Instruction.resetGlobalId();
+        Instruction i3 = new Instruction(Instruction.ZERO_16);
+        assertEquals(1, i3.getId());
+    }
+
+    @Test
+    void testDefaultStage() {
+        Instruction instr = new Instruction(Instruction.ZERO_16);
+        assertEquals(InstructionStage.FETCH, instr.getInstructionStage());
+        instr.setInstructionStage(InstructionStage.EXECUTE);
+        assertEquals(InstructionStage.EXECUTE, instr.getInstructionStage());
+    }
+}


### PR DESCRIPTION
## Summary
- configure Maven with JUnit Jupiter engine and Surefire plugin
- add extensive unit tests for helper operations, control logic, pipeline registers, and processing units

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a09fc20c83258ed9d80eea6cc4d2